### PR TITLE
fix: bump parse url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3861,20 +3861,20 @@
       }
     },
     "git-up": {
-      "version": "6.0.0",
-      "resolved": "https://artifactory.concurtech.net/artifactory/api/npm/npm-aggregate/git-up/-/git-up-6.0.0.tgz",
-      "integrity": "sha512-6RUFSNd1c/D0xtGnyWN2sxza2bZtZ/EmI9448n6rCZruFwV/ezeEn2fJP7XnUQGwf0RAtd/mmUCbtH6JPYA2SA==",
+      "version": "7.0.0",
+      "resolved": "https://artifactory.concurtech.net/artifactory/api/npm/npm-aggregate/git-up/-/git-up-7.0.0.tgz",
+      "integrity": "sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==",
       "requires": {
         "is-ssh": "^1.4.0",
-        "parse-url": "^7.0.2"
+        "parse-url": "^8.1.0"
       }
     },
     "git-url-parse": {
-      "version": "12.0.0",
-      "resolved": "https://artifactory.concurtech.net/artifactory/api/npm/npm-aggregate/git-url-parse/-/git-url-parse-12.0.0.tgz",
-      "integrity": "sha512-I6LMWsxV87vysX1WfsoglXsXg6GjQRKq7+Dgiseo+h0skmp5Hp2rzmcEIRQot9CPA+uzU7x1x7jZdqvTFGnB+Q==",
+      "version": "13.0.0",
+      "resolved": "https://artifactory.concurtech.net/artifactory/api/npm/npm-aggregate/git-url-parse/-/git-url-parse-13.0.0.tgz",
+      "integrity": "sha512-X1kozCqKL82dMrCLi4vie9SHDC+QugKskAMs4VUbIkhURKg5yDwxDmf6Ixg73J+/xVgK5TXKhzn8a94nHJHpnA==",
       "requires": {
-        "git-up": "^6.0.0"
+        "git-up": "^7.0.0"
       }
     },
     "gitconfiglocal": {
@@ -4676,11 +4676,6 @@
       "dev": true,
       "optional": true
     },
-    "normalize-url": {
-      "version": "6.1.0",
-      "resolved": "https://artifactory.concurtech.net/artifactory/api/npm/npm-aggregate/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
-    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -4813,22 +4808,19 @@
       }
     },
     "parse-path": {
-      "version": "5.0.0",
-      "resolved": "https://artifactory.concurtech.net/artifactory/api/npm/npm-aggregate/parse-path/-/parse-path-5.0.0.tgz",
-      "integrity": "sha512-qOpH55/+ZJ4jUu/oLO+ifUKjFPNZGfnPJtzvGzKN/4oLMil5m9OH4VpOj6++9/ytJcfks4kzH2hhi87GL/OU9A==",
+      "version": "7.0.0",
+      "resolved": "https://artifactory.concurtech.net/artifactory/api/npm/npm-aggregate/parse-path/-/parse-path-7.0.0.tgz",
+      "integrity": "sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==",
       "requires": {
         "protocols": "^2.0.0"
       }
     },
     "parse-url": {
-      "version": "7.0.2",
-      "resolved": "https://artifactory.concurtech.net/artifactory/api/npm/npm-aggregate/parse-url/-/parse-url-7.0.2.tgz",
-      "integrity": "sha512-PqO4Z0eCiQ08Wj6QQmrmp5YTTxpYfONdOEamrtvK63AmzXpcavIVQubGHxOEwiIoDZFb8uDOoQFS0NCcjqIYQg==",
+      "version": "8.1.0",
+      "resolved": "https://artifactory.concurtech.net/artifactory/api/npm/npm-aggregate/parse-url/-/parse-url-8.1.0.tgz",
+      "integrity": "sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==",
       "requires": {
-        "is-ssh": "^1.4.0",
-        "normalize-url": "^6.1.0",
-        "parse-path": "^5.0.0",
-        "protocols": "^2.0.1"
+        "parse-path": "^7.0.0"
       }
     },
     "path-exists": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/greg-a-smith/github-assistant#readme",
   "dependencies": {
-    "git-url-parse": "^12.0.0",
+    "git-url-parse": "^13.0.0",
     "github-api": "^3.4.0",
     "loglevel": "^1.6.1",
     "ncp": "^2.0.0",


### PR DESCRIPTION
Bump git-parse-url for parse-url vulnerability

Nothing is jumping out to me as an issue:
https://github.com/IonicaBizau/parse-url/releases/tag/8.0.0
https://github.com/IonicaBizau/git-url-parse/releases/tag/13.0.0